### PR TITLE
Serialize objects with Django standard serializer

### DIFF
--- a/admino/sites.py
+++ b/admino/sites.py
@@ -123,12 +123,12 @@ class AdminoMixin(object):
     def obj_as_dict(self, request, obj):
         data = self.serialize_obj(obj)
         for field in obj._meta.get_fields():
-            if field.is_relation:
+            if field.is_relation and field.concrete:
                 field_value = getattr(obj, field.name)
                 if field_value:
                     if field.many_to_many:                    
                         data[field.name] = self.serialize_objs(field_value.all())
-                    elif field.many_to_one or field.one_to_one or field_value.one_to_many:
+                    elif field.many_to_one or field.one_to_one or field.one_to_many:
                         data[field.name] = self.serialize_obj(field_value)
         return data
 


### PR DESCRIPTION
IntegersFields, FloatsFields and None were serialized as strings, actually is the unicode representation of the field. This doesn't produce a valid JSON.

The correct representation in JSON for integers is integers, float is float and None is null.

For achieve a correct representation of the model I have used the standard django serializer, so we don't have to worry about any special cases in the future. 

This patch also resolves GenericForeignKey's
